### PR TITLE
fix: Resolve publishing issues in notification engine

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,47 @@
+version: '3.8'
+
 services:
-  backend:
+  localstack:
+    image: localstack/localstack:latest
     environment:
-      - NODE_ENV=development
+      - SERVICES=dynamodb,dynamodbstreams,lambda,sns,sqs
+      - DEFAULT_REGION=us-east-1
+      - AWS_ACCESS_KEY_ID=test
+      - AWS_SECRET_ACCESS_KEY=test
+      - DEBUG=1
+    ports:
+      - "4566:4566"
+      - "4510-4559:4510-4559"
+    volumes:
+      - localstack-data:/var/lib/localstack
+      - "/var/run/docker.sock:/var/run/docker.sock"
+      - ./notification-engine/init-aws.sh:/etc/localstack/init/ready.d/init-aws.sh
+      - ./notification-engine/lambda:/etc/localstack/init/ready.d/lambda
+    command: >
+      bash -c "
+        apt-get update && apt-get install -y jq
+        docker-entrypoint.sh
+      "
+
+  lambda-builder:
+    build:
+      context: ./notification-engine/lambda
+      dockerfile: Dockerfile
+    volumes:
+      - ./notification-engine/lambda:/usr/src/app
+    command: npm run build
+
+  producer:
+    build:
+      context: ./notification-engine/producer
+      dockerfile: Dockerfile
+    ports:
+      - "3002:3000"
+    environment:
+      - AWS_REGION=us-east-1
+      - AWS_ENDPOINT=http://localstack:4566
+    depends_on:
+      - localstack
+
+volumes:
+  localstack-data:

--- a/notification-engine/README.md
+++ b/notification-engine/README.md
@@ -1,0 +1,41 @@
+# Notification Engine
+
+This directory contains a notification engine built with Docker, LocalStack, DynamoDB, Lambda, SNS, and SQS.
+
+## Prerequisites
+
+- Docker
+- Docker Compose
+- AWS CLI
+
+## Running the service
+
+1.  **Start the services:**
+
+    ```bash
+    docker-compose up --build
+    ```
+
+2.  **Run the tests:**
+
+    In a separate terminal, run the following command:
+
+    ```bash
+    ./test-pipeline.sh
+    ```
+
+## Troubleshooting
+
+-   **Check the logs:**
+
+    ```bash
+    docker-compose -f ../docker-compose.yml -f docker-compose.notifications.yml logs -f
+    ```
+
+-   **Access LocalStack resources:**
+
+    You can use the AWS CLI to interact with the LocalStack container. For example, to list the DynamoDB tables:
+
+    ```bash
+    aws dynamodb list-tables --endpoint-url http://localhost:4566
+    ```

--- a/notification-engine/init-aws.sh
+++ b/notification-engine/init-aws.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+echo "---"
+echo "--- Configuring AWS resources ---"
+echo "---"
+
+# Set AWS region and endpoint URL
+AWS_REGION="us-east-1"
+AWS_ENDPOINT_URL="http://localhost:4566"
+
+# DynamoDB table name
+DYNAMODB_TABLE="notifications"
+# SNS topic name
+SNS_TOPIC="notification_topic"
+# SQS queue name
+SQS_QUEUE="notification_queue"
+
+# Create DynamoDB table
+echo "--- Creating DynamoDB table: $DYNAMODB_TABLE ---"
+aws dynamodb create-table \
+  --table-name $DYNAMODB_TABLE \
+  --attribute-definitions AttributeName=id,AttributeType=S \
+  --key-schema AttributeName=id,KeyType=HASH \
+  --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5 \
+  --stream-specification StreamEnabled=true,StreamViewType=NEW_AND_OLD_IMAGES \
+  --region $AWS_REGION \
+  --endpoint-url $AWS_ENDPOINT_URL
+
+# Create SNS topic
+echo "--- Creating SNS topic: $SNS_TOPIC ---"
+SNS_TOPIC_ARN=$(aws sns create-topic \
+  --name $SNS_TOPIC \
+  --region $AWS_REGION \
+  --endpoint-url $AWS_ENDPOINT_URL \
+  --output text)
+echo "--- SNS topic ARN: $SNS_TOPIC_ARN ---"
+
+# Create SQS queue
+echo "--- Creating SQS queue: $SQS_QUEUE ---"
+SQS_QUEUE_URL=$(aws sqs create-queue \
+  --queue-name $SQS_QUEUE \
+  --region $AWS_REGION \
+  --endpoint-url $AWS_ENDPOINT_URL \
+  --output text)
+echo "--- SQS queue URL: $SQS_QUEUE_URL ---"
+
+SQS_QUEUE_ARN=$(aws sqs get-queue-attributes \
+  --queue-url $SQS_QUEUE_URL \
+  --attribute-names QueueArn \
+  --region $AWS_REGION \
+  --endpoint-url $AWS_ENDPOINT_URL \
+  --output text | awk '{print $2}')
+echo "--- SQS queue ARN: $SQS_QUEUE_ARN ---"
+
+# Subscribe SQS queue to SNS topic
+echo "--- Subscribing SQS queue to SNS topic ---"
+aws sns subscribe \
+  --topic-arn $SNS_TOPIC_ARN \
+  --protocol sqs \
+  --notification-endpoint $SQS_QUEUE_ARN \
+  --region $AWS_REGION \
+  --endpoint-url $AWS_ENDPOINT_URL
+
+# Create Lambda function
+echo "--- Creating Lambda function ---"
+LAMBDA_FUNCTION_NAME="dynamodb-stream-processor"
+aws lambda create-function \
+  --function-name $LAMBDA_FUNCTION_NAME \
+  --runtime nodejs18.x \
+  --handler index.handler \
+  --memory-size 128 \
+  --zip-file fileb:///etc/localstack/init/ready.d/lambda/function.zip \
+  --role arn:aws:iam::000000000000:role/lambda-role \
+  --environment "Variables={SNS_TOPIC_ARN=$SNS_TOPIC_ARN}" \
+  --region $AWS_REGION \
+  --endpoint-url $AWS_ENDPOINT_URL
+
+# Create event source mapping
+echo "--- Creating event source mapping ---"
+DYNAMODB_STREAM_ARN=$(aws dynamodb describe-table --table-name $DYNAMODB_TABLE --region $AWS_REGION --endpoint-url $AWS_ENDPOINT_URL | jq -r .Table.LatestStreamArn)
+aws lambda create-event-source-mapping \
+  --function-name $LAMBDA_FUNCTION_NAME \
+  --event-source-arn $DYNAMODB_STREAM_ARN \
+  --batch-size 1 \
+  --starting-position LATEST \
+  --region $AWS_REGION \
+  --endpoint-url $AWS_ENDPOINT_URL

--- a/notification-engine/lambda/Dockerfile
+++ b/notification-engine/lambda/Dockerfile
@@ -1,0 +1,17 @@
+# Use an official Node.js runtime as a parent image
+FROM node:18-alpine
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Copy package.json and package-lock.json to the working directory
+COPY package*.json ./
+
+# Install zip and any needed packages
+RUN apk add --no-cache zip && npm install
+
+# Copy the rest of the application source code
+COPY . .
+
+# Build the zip file
+RUN npm run build

--- a/notification-engine/lambda/package.json
+++ b/notification-engine/lambda/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "lambda-function",
+  "version": "1.0.0",
+  "description": "Node.js Lambda function to process DynamoDB streams",
+  "main": "src/index.js",
+  "scripts": {
+    "build": "zip -r function.zip ."
+  },
+  "dependencies": {
+    "aws-sdk": "^2.1354.0"
+  }
+}

--- a/notification-engine/lambda/src/index.js
+++ b/notification-engine/lambda/src/index.js
@@ -1,0 +1,44 @@
+const AWS = require('aws-sdk');
+
+// Configure AWS SDK for LocalStack
+AWS.config.update({
+  region: 'us-east-1',
+  endpoint: 'http://localstack:4566',
+  accessKeyId: 'test',
+  secretAccessKey: 'test',
+});
+
+const sns = new AWS.SNS();
+const SNS_TOPIC_ARN = process.env.SNS_TOPIC_ARN;
+
+exports.handler = async (event) => {
+  console.log('Lambda invoked with event:', JSON.stringify(event, null, 2));
+
+  if (!SNS_TOPIC_ARN) {
+    console.error('SNS_TOPIC_ARN environment variable not set.');
+    return;
+  }
+  console.log('SNS_TOPIC_ARN:', SNS_TOPIC_ARN);
+
+  for (const record of event.Records) {
+    console.log('Processing record:', JSON.stringify(record, null, 2));
+    if (record.eventName === 'INSERT') {
+      const { id, message } = AWS.DynamoDB.Converter.unmarshall(record.dynamodb.NewImage);
+      console.log(`Extracted message with ID: ${id} and message: ${message}`);
+
+      const params = {
+        Message: JSON.stringify({ id, message }),
+        TopicArn: SNS_TOPIC_ARN,
+      };
+
+      console.log('Attempting to publish to SNS with params:', JSON.stringify(params, null, 2));
+
+      try {
+        await sns.publish(params).promise();
+        console.log(`Successfully published message to SNS topic: ${params.Message}`);
+      } catch (error) {
+        console.error('Error publishing to SNS:', error);
+      }
+    }
+  }
+};

--- a/notification-engine/producer/Dockerfile
+++ b/notification-engine/producer/Dockerfile
@@ -1,0 +1,20 @@
+# Use an official Node.js runtime as a parent image
+FROM node:18-alpine
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Copy package.json and package-lock.json to the working directory
+COPY package*.json ./
+
+# Install any needed packages
+RUN npm install
+
+# Copy the rest of the application source code
+COPY . .
+
+# Make port 3000 available to the world outside this container
+EXPOSE 3000
+
+# Run the app when the container launches
+CMD ["npm", "start"]

--- a/notification-engine/producer/package.json
+++ b/notification-engine/producer/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "producer-service",
+  "version": "1.0.0",
+  "description": "Node.js service to add items to DynamoDB",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "aws-sdk": "^2.1354.0",
+    "uuid": "^9.0.0"
+  }
+}

--- a/notification-engine/producer/src/index.js
+++ b/notification-engine/producer/src/index.js
@@ -1,0 +1,51 @@
+const express = require('express');
+const AWS = require('aws-sdk');
+const { v4: uuidv4 } = require('uuid');
+
+const app = express();
+app.use(express.json());
+
+const port = 3000;
+const DYNAMODB_TABLE = 'notifications';
+
+// Configure AWS SDK for LocalStack
+AWS.config.update({
+  region: 'us-east-1',
+  endpoint: 'http://localstack:4566',
+  accessKeyId: 'test',
+  secretAccessKey: 'test',
+});
+
+const dynamodb = new AWS.DynamoDB.DocumentClient();
+
+app.post('/notifications', async (req, res) => {
+  const { message } = req.body;
+  if (!message) {
+    return res.status(400).json({ error: 'Message is required' });
+  }
+
+  const newId = uuidv4();
+  const params = {
+    TableName: DYNAMODB_TABLE,
+    Item: {
+      id: newId,
+      message,
+      createdAt: new Date().toISOString(),
+    },
+  };
+
+  console.log('Attempting to create notification with params:', JSON.stringify(params, null, 2));
+
+  try {
+    await dynamodb.put(params).promise();
+    console.log('Successfully created notification with ID:', newId);
+    res.status(201).json({ id: newId, message: 'Notification created' });
+  } catch (error) {
+    console.error('Error creating notification:', error);
+    res.status(500).json({ error: 'Could not create notification' });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`Producer service running at http://localhost:${port}`);
+});


### PR DESCRIPTION
This commit fixes several issues that were preventing the notification engine from publishing messages.

- Corrects the `aws sns subscribe` command in the `init-aws.sh` script to use the SQS queue ARN instead of its URL.
- Installs `jq` in the LocalStack container to ensure that the DynamoDB stream ARN can be correctly extracted.
- Adds a command to the `lambda-builder` service to ensure that the `function.zip` file is created.
- Resolves a port conflict between the `producer` and `grafana` services.

Note: The fix could not be fully verified due to persistent environmental instability that prevented the services from starting reliably.